### PR TITLE
adding the new links to the new heroku db

### DIFF
--- a/client/src/components/profilePicNameLoc.js
+++ b/client/src/components/profilePicNameLoc.js
@@ -33,7 +33,6 @@ var ProfilePicture = React.createClass({
               <img className="img-circle" src={'http://i.imgur.com/eWVQuDJ.png'} />
               <h4>{this.state.username}</h4>
               <p>{this.state.location}</p>
-              <p>Hello from the profilepicname component</p>
                <div className="panel-body">
                   <div className="expandable expandable-indicator-white expandable-trigger">
               <div className="expandable-content">

--- a/server/config.js
+++ b/server/config.js
@@ -3,7 +3,7 @@ module.exports = {
 
     /* Change the database name to your local machine's name*/
 
-    databaseURL: process.env.DATABASE_URL || 'postgres://localhost:5432/glenngonda'
+    // databaseURL: process.env.DATABASE_URL || 'postgres://localhost:5432/glenngonda'
 
 
     // databaseURL: process.env.DATABASE_URL || 'postgres://localhost:5432/kmerino'
@@ -13,11 +13,11 @@ module.exports = {
     /* This is used for the PostGres DB server */
     /*
     In the terminal, first export the link to the PG DB: 
-      export DATABASE_URL='postgres://mlsnfeluxqiuff:9ChVkwF-1ypBrOsmB_kNV8rEDi@ec2-54-197-245-93.compute-1.amazonaws.com:5432/de5lornqrnncva'
+      export DATABASE_URL='postgres://qacakftnxcikfj:fppgETRZp0te0xzfcKgihjywYN@ec2-54-243-149-147.compute-1.amazonaws.com:5432/d4etla2a7iv9n3'
     Then run nodemon: 
-      DATABASE_URL='postgres://mlsnfeluxqiuff:9ChVkwF-1ypBrOsmB_kNV8rEDi@ec2-54-197-245-93.compute-1.amazonaws.com:5432/de5lornqrnncva?ssl=true' nodemon app.js
-    If the Heroku toolbelt and the PGAdmin are both installed, run the following to access the PG DB in ther terminal: 
-      heroku pg:psql --app habitudein30
+      DATABASE_URL='postgres://qacakftnxcikfj:fppgETRZp0te0xzfcKgihjywYN@ec2-54-243-149-147.compute-1.amazonaws.com:5432/d4etla2a7iv9n3?ssl=true' nodemon app.js
+    If the Heroku toolbelt and the PGAdmin are both installed, run the following to access the PG DB in the terminal: 
+      heroku pg:psql --app habitudein30 HEROKU_POSTGRESQL_TEAL
     */
-    // databaseURL: process.env.DATABASE_URL || 'postgres://mlsnfeluxqiuff:9ChVkwF-1ypBrOsmB_kNV8rEDi@ec2-54-197-245-93.compute-1.amazonaws.com:5432/de5lornqrnncva'
+    databaseURL: process.env.DATABASE_URL || 'postgres://qacakftnxcikfj:fppgETRZp0te0xzfcKgihjywYN@ec2-54-243-149-147.compute-1.amazonaws.com:5432/d4etla2a7iv9n3'
 };


### PR DESCRIPTION
Since I had to re-deploy our app, I had to give it a new db. It's now up to date with all the SQL tables and dummy data. Also, in config.js I've updated the code you can use to copy and paste into the terminal to access the new heroku pg db.
